### PR TITLE
Bumps base image version to v24 if tagged this way

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cloutainer/k8s-jenkins-slave-base:v22
+FROM cloutainer/k8s-jenkins-slave-base:v24
 
 #
 # BASE PACKAGES


### PR DESCRIPTION
Follow-up PR after merging the ssh_client PR https://github.com/cloutainer/k8s-jenkins-slave-base/pull/1, in case it is fine for you.
Cheers!